### PR TITLE
Project enhancement: Exclude `sb-vite` from optimizeDeps

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -12,6 +12,20 @@ const config = {
     "@chromatic-com/storybook",
     "@storybook/addon-interactions",
   ],
+  core: {
+    builder: '@storybook/builder-vite',
+  },
+  async viteFinal(config) {
+    // Merge custom configuration into the default config
+    const { mergeConfig } = await import('vite');
+
+    return mergeConfig(config, {
+      // Add dependencies to pre-optimization
+      optimizeDeps: {
+        exclude: ['sb-vite'],
+      },
+    });
+  },
   framework: {
     name: "@storybook/html-vite",
     options: {},


### PR DESCRIPTION
# Summary

Update `main.js` to exclude `sb-vite` from dependency optimization, to prevent a build error.

Work is based on the example configuration in the [Storybook Vite documentation](https://storybook.js.org/docs/builders/vite#configuration) 

Closes #14 