### PR TITLE
Dependencies: Downgrade sass to prevent large terminal warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@storybook/html": "^8.2.2",
         "@storybook/html-vite": "^8.2.2",
         "@storybook/test": "^8.2.2",
-        "sass": "^1.77.8",
+        "sass": "^1.77.0",
         "storybook": "^8.2.2",
         "vite-plugin-twig-drupal": "^1.3.0"
       }
@@ -7270,9 +7270,9 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
-      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.0.tgz",
+      "integrity": "sha512-eGj4HNfXqBWtSnvItNkn7B6icqH14i3CiCGbzMKs3BAPTq62pp9NBYsBgyN4cA+qssqo9r26lW4JSvlaUUWbgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@storybook/html": "^8.2.2",
         "@storybook/html-vite": "^8.2.2",
         "@storybook/test": "^8.2.2",
-        "sass": "^1.77.0",
+        "sass": "^1.77.6",
         "storybook": "^8.2.2",
         "vite-plugin-twig-drupal": "^1.3.0"
       }
@@ -7270,9 +7270,9 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.77.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.0.tgz",
-      "integrity": "sha512-eGj4HNfXqBWtSnvItNkn7B6icqH14i3CiCGbzMKs3BAPTq62pp9NBYsBgyN4cA+qssqo9r26lW4JSvlaUUWbgw==",
+      "version": "1.77.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.6.tgz",
+      "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@storybook/html": "^8.2.2",
     "@storybook/html-vite": "^8.2.2",
     "@storybook/test": "^8.2.2",
-    "sass": "^1.77.8",
+    "sass": "^1.77.0",
     "storybook": "^8.2.2",
     "vite-plugin-twig-drupal": "^1.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@storybook/html": "^8.2.2",
     "@storybook/html-vite": "^8.2.2",
     "@storybook/test": "^8.2.2",
-    "sass": "^1.77.0",
+    "sass": "^1.77.6",
     "storybook": "^8.2.2",
     "vite-plugin-twig-drupal": "^1.3.0"
   },


### PR DESCRIPTION
# Summary

Downgrading Sass from `1.77.8` to `1.77.6` removes the sass warnings that aren't necessary for this project.

Sass [changelog](https://github.com/sass/dart-sass/blob/main/CHANGELOG.md#1778) for reference

Closes #16 